### PR TITLE
Incorrect escape on diff fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.1 (provisional)
+- Escape remaining keys before comparing them to the (already escaped) keys from earlier in the diffing process when determining Remove operations
+
 # 1.0.0
 - Allow lists at top level of Jsonpatch.apply_patch
 - Fix error message when updating a non existing key in list

--- a/lib/jsonpatch.ex
+++ b/lib/jsonpatch.ex
@@ -160,7 +160,7 @@ defmodule Jsonpatch do
     acc =
       source
       |> flat()
-      |> Stream.map(fn {k, _} -> k end)
+      |> Stream.map(fn {k, _} -> escape(k) end)
       |> Stream.filter(fn k -> k not in checked_keys end)
       |> Stream.map(fn k -> %Remove{path: "#{ancestor_path}/#{k}"} end)
       |> Enum.reduce(acc, fn r, acc -> [r | acc] end)

--- a/test/jsonpatch_test.exs
+++ b/test/jsonpatch_test.exs
@@ -107,13 +107,32 @@ defmodule JsonpatchTest do
              ] = patch
     end
 
-    test "Create diff with escaped '~' and '/' in path" do
+    test "Create diff with escaped '~' and '/' in path when adding" do
       source = %{}
       destination = %{"escape/me~now" => "somnevalue"}
 
       actual_patch = Jsonpatch.diff(source, destination)
 
       assert [%Jsonpatch.Operation.Add{path: "/escape~1me~0now", value: "somnevalue"}] =
+               actual_patch
+    end
+
+    test "Create diff with escaped '~' and '/' in path when removing" do
+      source = %{"escape/me~now" => "somnevalue"}
+      destination = %{}
+
+      actual_patch = Jsonpatch.diff(source, destination)
+
+      assert [%Jsonpatch.Operation.Remove{path: "/escape~1me~0now"}] = actual_patch
+    end
+
+    test "Create diff with escaped '~' and '/' in path when replacing" do
+      source = %{"escape/me~now" => "somnevalue"}
+      destination = %{"escape/me~now" => "othervalue"}
+
+      actual_patch = Jsonpatch.diff(source, destination)
+
+      assert [%Jsonpatch.Operation.Replace{path: "/escape~1me~0now", value: "othervalue"}] =
                actual_patch
     end
 


### PR DESCRIPTION
Found when using Jsonpatch with OpenAPI documents. When diffing documents with characters in need of escaping, at the stage of determining paths to remove, the `checked_paths` list has the paths already escaped, whereas the path to-be-checked is not. This means that `Remove` operations are created for every path with unescaped path attributes.