### PR TITLE
Treat nil values differently from missing keys

### DIFF
--- a/lib/jsonpatch.ex
+++ b/lib/jsonpatch.ex
@@ -175,7 +175,7 @@ defmodule Jsonpatch do
     acc =
       case get(source, key) do
         # Key is not present in source
-        nil ->
+        :__jsonpatch_lib__missing_value__ ->
           [%Add{path: current_path, value: val} | acc]
 
         # Source has a different value but both (destination and source) value are lists or a maps
@@ -209,11 +209,11 @@ defmodule Jsonpatch do
 
   # Unified access to lists or maps
   defp get(source, key) when is_list(source) do
-    Enum.at(source, key)
+    Enum.at(source, key, :__jsonpatch_lib__missing_value__)
   end
 
   defp get(source, key) when is_map(source) do
-    Map.get(source, key)
+    Map.get(source, key, :__jsonpatch_lib__missing_value__)
   end
 
   # Escape `/` to `~1 and `~` to `~0`.

--- a/test/jsonpatch_test.exs
+++ b/test/jsonpatch_test.exs
@@ -50,6 +50,19 @@ defmodule JsonpatchTest do
       assert [%Remove{path: "/baz"}] = patch
     end
 
+    test "Create no diff on unchanged nil object value" do
+      source = %{"id" => nil}
+      destination = %{"id" => nil}
+      assert [] = Jsonpatch.diff(source, destination)
+    end
+
+    test "Create no diff on unchanged array value" do
+      source = [nil]
+      destination = [nil]
+
+      assert [] = Jsonpatch.diff(source, destination)
+    end
+
     test "Create no diff on unexpected input" do
       assert [] = Jsonpatch.diff("unexpected", 1)
     end


### PR DESCRIPTION
Hey! :wave: 

I have a proposed fix for #16, I've added a default to the `get/2` function which returns `:missing` when a key is missing instead of `nil` - this appears to disambiguate nils and missing keys.

I'm not _crazy_ about my use of an atom like `:missing` here, like you really never really know what a users data is going to be. Thoughts?

Fixes #16 