### PR TITLE
Add ignore_invalid_paths to patch

### DIFF
--- a/lib/jsonpatch/types.ex
+++ b/lib/jsonpatch/types.ex
@@ -23,7 +23,7 @@ defmodule Jsonpatch.Types do
   - `:atoms!` - path fragments are converted to existing atoms
   - `{:custom, convert_fn}` - path fragments are converted with `convert_fn`
   """
-  @type opt_keys :: :strings | :atoms | {:custom, convert_fn()}
+  @type opt_keys :: :strings | :atoms | {:custom, convert_fn()} | {:ignore_invalid_paths, :boolean}
 
   @typedoc """
   Types options:

--- a/test/jsonpatch_test.exs
+++ b/test/jsonpatch_test.exs
@@ -422,6 +422,13 @@ defmodule JsonpatchTest do
                 reason: {:invalid_path, ""}
               }} = Jsonpatch.apply_patch(patch, target)
     end
+
+    test "ignore invalid paths when asked to" do
+      patch = %{"op" => "replace", "path" => "/inexistent", "value" => 42}
+      target = %{"foo" => "bar"}
+
+      assert {:ok, %{"foo" => "bar"}} = Jsonpatch.apply_patch(patch, target, ignore_invalid_paths: true)
+    end
   end
 
   defp string_to_existing_atom(data) when is_binary(data) do


### PR DESCRIPTION
Sometimes it's necessary to apply a patch to a JSON that may lack certain operation paths. In this scenario, it would be great to have an option to ignore the invalid paths. I provide the following example:

```
      iex> # Patch will succeed, not applying invalid path operations.
      iex> patch = [
      ...> %{op: "replace", path: "/name", value: "Alice"},
      ...> %{op: "replace", path: "/age", value: 42}
      ...> ]
      iex> target = %{"name" => "Bob"} # No age in target
      iex> Jsonpatch.apply_patch(patch, target, ignore_invalid_paths: true)
      {:ok, %{"name" => "Alice"}}
```

Thanks for this great library. Simple and useful!
Tulo