### PR TITLE
Resolves an issues preventing move working with keys: :atoms

### DIFF
--- a/lib/jsonpatch/operation/copy.ex
+++ b/lib/jsonpatch/operation/copy.ex
@@ -21,7 +21,7 @@ defmodule Jsonpatch.Operation.Copy do
   @spec apply(Jsonpatch.t(), target :: Types.json_container(), Types.opts()) ::
           {:ok, Types.json_container()} | Types.error()
   def apply(%Copy{from: from, path: path}, target, opts) do
-    with {:ok, destination} <- Utils.get_destination(target, from),
+    with {:ok, destination} <- Utils.get_destination(target, from, opts),
          {:ok, from_fragments} = Utils.split_path(from),
          {:ok, copy_value} <- extract_copy_value(destination, from_fragments) do
       Add.apply(%Add{value: copy_value, path: path}, target, opts)

--- a/test/jsonpatch/operation/move_test.exs
+++ b/test/jsonpatch/operation/move_test.exs
@@ -3,4 +3,11 @@ defmodule Jsonpatch.Operation.MoveTest do
   doctest Jsonpatch.Operation.Move
 
   # Move is a combination of the copy and remove operation.
+  test "move a value with atoms" do
+    move = %Jsonpatch.Operation.Move{from: "/a/b", path: "/a/e"}
+    target = %{a: %{b: %{c: "Bob"}}, d: false}
+
+    assert Jsonpatch.Operation.Move.apply(move, target, keys: :atoms) ==
+             {:ok, %{a: %{e: %{c: "Bob"}}, d: false}}
+  end
 end


### PR DESCRIPTION
Enables

```
move = %Jsonpatch.Operation.Move{from: "/a/b", path: "/a/e"}
target = %{a: %{b: %{c: "Bob"}}, d: false}
Jsonpatch.Operation.Move.apply(move, target, keys: :atoms)
```

To work, previously this would return an error.