### PR TITLE
Performance optimizations - Dedicated functions for map and list diffs

### DIFF
--- a/lib/jsonpatch.ex
+++ b/lib/jsonpatch.ex
@@ -225,10 +225,10 @@ defmodule Jsonpatch do
     # The complete desination was check. Every key that is not in the list of
     # checked keys, must be removed.
     Enum.reduce(source, patches, fn {k, _}, patches ->
-      if k not in checked_keys do
-        [%{op: "remove", path: "#{ancestor_path}/#{escape(k)}"} | patches]
-      else
+      if k in checked_keys do
         patches
+      else
+        [%{op: "remove", path: "#{ancestor_path}/#{escape(k)}"} | patches]
       end
     end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,8 @@ defmodule Jsonpatch.MixProject do
       {:credo, "~> 1.7.5", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.31", only: [:dev], runtime: false},
-      {:jason, "~> 1.4", only: [:dev, :test]}
+      {:jason, "~> 1.4", only: [:dev, :test]},
+      {:benchee, "~> 1.4", only: [:dev]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{
+  "benchee": {:hex, :benchee, "1.4.0", "9f1f96a30ac80bab94faad644b39a9031d5632e517416a8ab0a6b0ac4df124ce", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}, {:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: true]}], "hexpm", "299cd10dd8ce51c9ea3ddb74bb150f93d25e968f93e4c1fa31698a8e4fa5d715"},
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "credo": {:hex, :credo, "1.7.5", "643213503b1c766ec0496d828c90c424471ea54da77c8a168c725686377b9545", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "f799e9b5cd1891577d8c773d245668aa74a2fcd15eb277f51a0131690ebfb3fd"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.4.3", "edd0124f358f0b9e95bfe53a9fcf806d615d8f838e2202a9f430d59566b6b53b", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "bf2cfb75cd5c5006bec30141b131663299c661a864ec7fbbc72dfa557487a986"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.39", "424642f8335b05bb9eb611aa1564c148a8ee35c9c8a8bba6e129d51a3e3c6769", [:mix], [], "hexpm", "06553a88d1f1846da9ef066b87b57c6f605552cfbe40d20bd8d59cc6bde41944"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
@@ -19,5 +21,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
+  "statistex": {:hex, :statistex, "1.1.0", "7fec1eb2f580a0d2c1a05ed27396a084ab064a40cfc84246dbfb0c72a5c761e5", [:mix], [], "hexpm", "f5950ea26ad43246ba2cce54324ac394a4e7408fdcf98b8e230f503a0cba9cf5"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/benchmark.exs
+++ b/test/benchmark.exs
@@ -196,7 +196,7 @@ defmodule JsonpatchBenchmark do
                   "host" => "db.example.com",
                   "port" => 5432,
                   "name" => "myapp_production",
-                  "pool" => %{"size" => 20, "timeout" => 10000, "idle_timeout" => 30000}
+                  "pool" => %{"size" => 20, "timeout" => 10_000, "idle_timeout" => 30_000}
                 },
                 "cache" => %{
                   "host" => "redis.example.com",

--- a/test/benchmark.exs
+++ b/test/benchmark.exs
@@ -1,0 +1,254 @@
+# Jsonpatch Diff Performance Benchmark
+# Run with: mix run test/benchmark.exs
+
+defmodule JsonpatchBenchmark do
+  @doc """
+  Prepare complex test cases for benchmarking
+  """
+  def prepare_test_cases() do
+    %{
+      "Complex Maps - E-commerce Order" => %{
+        doc: %{
+          "order_id" => "12345",
+          "customer" => %{
+            "name" => "John Doe",
+            "email" => "john@example.com",
+            "address" => %{
+              "street" => "123 Main St",
+              "city" => "Springfield",
+              "country" => "USA"
+            }
+          },
+          "items" => %{
+            "item1" => %{"name" => "Laptop", "price" => 999.99, "quantity" => 1},
+            "item2" => %{"name" => "Mouse", "price" => 29.99, "quantity" => 2}
+          },
+          "status" => "pending",
+          "total" => 1059.97
+        },
+        expected: %{
+          "order_id" => "12345",
+          "customer" => %{
+            "name" => "John Doe",
+            "email" => "john.doe@example.com",
+            "address" => %{
+              "street" => "456 Oak Ave",
+              "city" => "Springfield",
+              "country" => "USA",
+              "zipcode" => "12345"
+            },
+            "phone" => "+1-555-0123"
+          },
+          "items" => %{
+            "item1" => %{"name" => "Gaming Laptop", "price" => 1299.99, "quantity" => 1},
+            "item3" => %{"name" => "Keyboard", "price" => 79.99, "quantity" => 1}
+          },
+          "status" => "confirmed",
+          "total" => 1379.98,
+          "discount" => 50.00
+        }
+      },
+      "Complex Lists - Task Management" => %{
+        doc: [
+          %{
+            "id" => 1,
+            "task" => "Write documentation",
+            "priority" => "high",
+            "completed" => false
+          },
+          %{"id" => 2, "task" => "Fix bug #123", "priority" => "medium", "completed" => true},
+          %{"id" => 3, "task" => "Review PR", "priority" => "low", "completed" => false},
+          %{"id" => 4, "task" => "Deploy to staging", "priority" => "high", "completed" => false},
+          %{"id" => 5, "task" => "Update tests", "priority" => "medium", "completed" => true}
+        ],
+        expected: [
+          %{
+            "id" => 1,
+            "task" => "Write comprehensive documentation",
+            "priority" => "high",
+            "completed" => true
+          },
+          %{
+            "id" => 6,
+            "task" => "Optimize database queries",
+            "priority" => "high",
+            "completed" => false
+          },
+          %{"id" => 3, "task" => "Review PR", "priority" => "medium", "completed" => false},
+          %{"id" => 7, "task" => "Setup monitoring", "priority" => "low", "completed" => false},
+          %{
+            "id" => 4,
+            "task" => "Deploy to production",
+            "priority" => "critical",
+            "completed" => false
+          }
+        ]
+      },
+      "Mixed Maps and Lists - Social Media Post" => %{
+        doc: %{
+          "post_id" => "abc123",
+          "content" => "Just had an amazing day!",
+          "author" => %{
+            "username" => "johndoe",
+            "followers" => 1250,
+            "verified" => false
+          },
+          "comments" => [
+            %{"user" => "alice", "text" => "Great to hear!", "likes" => 5},
+            %{"user" => "bob", "text" => "Awesome!", "likes" => 3}
+          ],
+          "tags" => ["happy", "life"],
+          "metadata" => %{
+            "created_at" => "2023-01-01T10:00:00Z",
+            "location" => "New York",
+            "device" => "mobile"
+          }
+        },
+        expected: %{
+          "post_id" => "abc123",
+          "content" => "Just had an absolutely amazing day! #blessed",
+          "author" => %{
+            "username" => "johndoe",
+            "followers" => 1275,
+            "verified" => true,
+            "display_name" => "John Doe"
+          },
+          "comments" => [
+            %{"user" => "alice", "text" => "Great to hear! So happy for you!", "likes" => 8},
+            %{"user" => "charlie", "text" => "Inspiring!", "likes" => 2},
+            %{"user" => "bob", "text" => "Awesome!", "likes" => 3, "reply_to" => "alice"}
+          ],
+          "tags" => ["happy", "life", "blessed", "inspiration"],
+          "metadata" => %{
+            "created_at" => "2023-01-01T10:00:00Z",
+            "updated_at" => "2023-01-01T10:15:00Z",
+            "location" => "New York",
+            "device" => "mobile",
+            "engagement_score" => 8.5
+          },
+          "reactions" => %{
+            "likes" => 45,
+            "shares" => 12,
+            "hearts" => 23
+          }
+        }
+      },
+      "Deep Nesting - Configuration Tree" => %{
+        doc: %{
+          "application" => %{
+            "name" => "MyApp",
+            "version" => "1.0.0",
+            "modules" => %{
+              "authentication" => %{
+                "enabled" => true,
+                "providers" => %{
+                  "oauth" => %{
+                    "google" => %{"client_id" => "123", "scopes" => ["email", "profile"]},
+                    "github" => %{"client_id" => "456", "scopes" => ["user:email"]}
+                  },
+                  "local" => %{"enabled" => true, "password_policy" => %{"min_length" => 8}}
+                }
+              },
+              "database" => %{
+                "primary" => %{
+                  "host" => "localhost",
+                  "port" => 5432,
+                  "name" => "myapp_db",
+                  "pool" => %{"size" => 10, "timeout" => 5000}
+                },
+                "replica" => %{
+                  "host" => "replica.example.com",
+                  "port" => 5432,
+                  "name" => "myapp_db"
+                }
+              }
+            }
+          }
+        },
+        expected: %{
+          "application" => %{
+            "name" => "MyApp",
+            "version" => "1.1.0",
+            "modules" => %{
+              "authentication" => %{
+                "enabled" => true,
+                "providers" => %{
+                  "oauth" => %{
+                    "google" => %{
+                      "client_id" => "123",
+                      "scopes" => ["email", "profile", "calendar"]
+                    },
+                    "github" => %{"client_id" => "789", "scopes" => ["user:email", "read:user"]},
+                    "microsoft" => %{"client_id" => "999", "scopes" => ["User.Read"]}
+                  },
+                  "local" => %{
+                    "enabled" => true,
+                    "password_policy" => %{"min_length" => 12, "require_symbols" => true}
+                  },
+                  "saml" => %{
+                    "enabled" => false,
+                    "metadata_url" => "https://sso.example.com/metadata"
+                  }
+                }
+              },
+              "database" => %{
+                "primary" => %{
+                  "host" => "db.example.com",
+                  "port" => 5432,
+                  "name" => "myapp_production",
+                  "pool" => %{"size" => 20, "timeout" => 10000, "idle_timeout" => 30000}
+                },
+                "cache" => %{
+                  "host" => "redis.example.com",
+                  "port" => 6379,
+                  "ttl" => 3600
+                }
+              },
+              "monitoring" => %{
+                "metrics" => %{"enabled" => true, "interval" => 60},
+                "logging" => %{"level" => "info", "format" => "json"}
+              }
+            },
+            "features" => %{
+              "feature_flags" => %{"new_ui" => true, "beta_features" => false}
+            }
+          }
+        }
+      }
+    }
+  end
+
+  @doc """
+  Run the benchmark
+  """
+  def run_benchmark() do
+    Benchee.run(
+      %{
+        # I was using it for performance comparision, now faster version is the default one
+        # "Faster JsonPatch" => fn %{doc: doc, expected: expected} ->
+        #   Jsonpatch.Faster.diff(doc, expected)
+        # end,
+        "JsonPatch" => fn %{doc: doc, expected: expected} ->
+          Jsonpatch.diff(doc, expected)
+        end
+      },
+      inputs: prepare_test_cases(),
+      warmup: 0.1,
+      time: 0.5,
+      memory_time: 0.2,
+      reduction_time: 0.2,
+      parallel: 2,
+      formatters: [
+        Benchee.Formatters.Console
+      ],
+      print: [
+        benchmarking: true,
+        configuration: false,
+        fast_warning: false
+      ]
+    )
+  end
+end
+
+# Run the benchmark
+JsonpatchBenchmark.run_benchmark()


### PR DESCRIPTION
Hi :wave: Thanks for an amazing library. While working on LiveVue patches, I've spotted some low-hanging fruits about performance of this package. So here I go 😄 

## Approach

First, I've created a small benchmark in `test/benchmark.exs` using Benchee (I've added it to mix.exs, only in dev). Then I've developed a new version of diff alongside existing one, and after being done I've replaced original code to create this PR. 

You can start benchmark by running `mix run test/benchmark.exs`, but currently it will only show numbers for existing implementation. To compare it to the old one we'd need to copy an old implementation into a separate module. 

## Overview of changes
My goal was to reduce the number of memory allocations. Each time I could skip creating a new object, I tried to do so. 

It turns out that a dedicated function for making a diff for maps and for lists is the best way, as it allows to write a highly-optimized code that almost entirely avoids memory allocations. 

## Results

In my tests new implementation is 2-3x faster, and consumes around 2.5 less memory. Log from benchee:

```
Benchmarking Faster JsonPatch with input Complex Lists - Task Management ...
Benchmarking Faster JsonPatch with input Complex Maps - E-commerce Order ...
Benchmarking Faster JsonPatch with input Deep Nesting - Configuration Tree ...
Benchmarking Faster JsonPatch with input Mixed Maps and Lists - Social Media Post ...
Benchmarking Original JsonPatch with input Complex Lists - Task Management ...
Benchmarking Original JsonPatch with input Complex Maps - E-commerce Order ...
Benchmarking Original JsonPatch with input Deep Nesting - Configuration Tree ...
Benchmarking Original JsonPatch with input Mixed Maps and Lists - Social Media Post ...
Calculating statistics...
Formatting results...

##### With input Complex Lists - Task Management #####
Name                         ips        average  deviation         median         99th %
Faster JsonPatch         93.72 K       10.67 μs    ±34.80%        9.67 μs       22.33 μs
Original JsonPatch       34.20 K       29.24 μs   ±315.50%       25.58 μs       69.88 μs

Comparison: 
Faster JsonPatch         93.72 K
Original JsonPatch       34.20 K - 2.74x slower +18.57 μs

Memory usage statistics:

Name                  Memory usage
Faster JsonPatch           8.27 KB
Original JsonPatch        21.97 KB - 2.66x memory usage +13.70 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name               Reduction count
Faster JsonPatch            1.10 K
Original JsonPatch          3.00 K - 2.73x reduction count +1.91 K

**All measurements for reduction count were the same**

##### With input Complex Maps - E-commerce Order #####
Name                         ips        average  deviation         median         99th %
Faster JsonPatch        100.00 K       10.00 μs   ±139.63%        8.75 μs       26.58 μs
Original JsonPatch       41.54 K       24.07 μs   ±283.08%       20.92 μs       49.00 μs

Comparison: 
Faster JsonPatch        100.00 K
Original JsonPatch       41.54 K - 2.41x slower +14.07 μs

Memory usage statistics:

Name                  Memory usage
Faster JsonPatch           7.34 KB
Original JsonPatch        16.30 KB - 2.22x memory usage +8.95 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name               Reduction count
Faster JsonPatch            0.98 K
Original JsonPatch          2.34 K - 2.39x reduction count +1.36 K

**All measurements for reduction count were the same**

##### With input Deep Nesting - Configuration Tree #####
Name                         ips        average  deviation         median         99th %
Faster JsonPatch         60.95 K       16.41 μs    ±26.29%       15.33 μs       28.21 μs
Original JsonPatch       24.94 K       40.10 μs    ±23.62%       38.13 μs       67.61 μs

Comparison: 
Faster JsonPatch         60.95 K
Original JsonPatch       24.94 K - 2.44x slower +23.69 μs

Memory usage statistics:

Name                  Memory usage
Faster JsonPatch          13.27 KB
Original JsonPatch        36.13 KB - 2.72x memory usage +22.86 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name               Reduction count
Faster JsonPatch            1.77 K
Original JsonPatch          4.70 K - 2.65x reduction count +2.93 K

**All measurements for reduction count were the same**
```

All tests are passing, so I have a pretty high confidence everything is working in the same way as before. Hope these changes will be useful! 