### PR TITLE
Greedy object hash

### DIFF
--- a/benchmarks/generic_benchmark.exs
+++ b/benchmarks/generic_benchmark.exs
@@ -1,0 +1,254 @@
+# Jsonpatch Diff Performance Benchmark
+# Run with: mix run test/benchmark.exs
+
+defmodule JsonpatchBenchmark do
+  @doc """
+  Prepare complex test cases for benchmarking
+  """
+  def prepare_test_cases() do
+    %{
+      "Complex Maps - E-commerce Order" => %{
+        doc: %{
+          "order_id" => "12345",
+          "customer" => %{
+            "name" => "John Doe",
+            "email" => "john@example.com",
+            "address" => %{
+              "street" => "123 Main St",
+              "city" => "Springfield",
+              "country" => "USA"
+            }
+          },
+          "items" => %{
+            "item1" => %{"name" => "Laptop", "price" => 999.99, "quantity" => 1},
+            "item2" => %{"name" => "Mouse", "price" => 29.99, "quantity" => 2}
+          },
+          "status" => "pending",
+          "total" => 1059.97
+        },
+        expected: %{
+          "order_id" => "12345",
+          "customer" => %{
+            "name" => "John Doe",
+            "email" => "john.doe@example.com",
+            "address" => %{
+              "street" => "456 Oak Ave",
+              "city" => "Springfield",
+              "country" => "USA",
+              "zipcode" => "12345"
+            },
+            "phone" => "+1-555-0123"
+          },
+          "items" => %{
+            "item1" => %{"name" => "Gaming Laptop", "price" => 1299.99, "quantity" => 1},
+            "item3" => %{"name" => "Keyboard", "price" => 79.99, "quantity" => 1}
+          },
+          "status" => "confirmed",
+          "total" => 1379.98,
+          "discount" => 50.00
+        }
+      },
+      "Complex Lists - Task Management" => %{
+        doc: [
+          %{
+            "id" => 1,
+            "task" => "Write documentation",
+            "priority" => "high",
+            "completed" => false
+          },
+          %{"id" => 2, "task" => "Fix bug #123", "priority" => "medium", "completed" => true},
+          %{"id" => 3, "task" => "Review PR", "priority" => "low", "completed" => false},
+          %{"id" => 4, "task" => "Deploy to staging", "priority" => "high", "completed" => false},
+          %{"id" => 5, "task" => "Update tests", "priority" => "medium", "completed" => true}
+        ],
+        expected: [
+          %{
+            "id" => 1,
+            "task" => "Write comprehensive documentation",
+            "priority" => "high",
+            "completed" => true
+          },
+          %{
+            "id" => 6,
+            "task" => "Optimize database queries",
+            "priority" => "high",
+            "completed" => false
+          },
+          %{"id" => 3, "task" => "Review PR", "priority" => "medium", "completed" => false},
+          %{"id" => 7, "task" => "Setup monitoring", "priority" => "low", "completed" => false},
+          %{
+            "id" => 4,
+            "task" => "Deploy to production",
+            "priority" => "critical",
+            "completed" => false
+          }
+        ]
+      },
+      "Mixed Maps and Lists - Social Media Post" => %{
+        doc: %{
+          "post_id" => "abc123",
+          "content" => "Just had an amazing day!",
+          "author" => %{
+            "username" => "johndoe",
+            "followers" => 1250,
+            "verified" => false
+          },
+          "comments" => [
+            %{"user" => "alice", "text" => "Great to hear!", "likes" => 5},
+            %{"user" => "bob", "text" => "Awesome!", "likes" => 3}
+          ],
+          "tags" => ["happy", "life"],
+          "metadata" => %{
+            "created_at" => "2023-01-01T10:00:00Z",
+            "location" => "New York",
+            "device" => "mobile"
+          }
+        },
+        expected: %{
+          "post_id" => "abc123",
+          "content" => "Just had an absolutely amazing day! #blessed",
+          "author" => %{
+            "username" => "johndoe",
+            "followers" => 1275,
+            "verified" => true,
+            "display_name" => "John Doe"
+          },
+          "comments" => [
+            %{"user" => "alice", "text" => "Great to hear! So happy for you!", "likes" => 8},
+            %{"user" => "charlie", "text" => "Inspiring!", "likes" => 2},
+            %{"user" => "bob", "text" => "Awesome!", "likes" => 3, "reply_to" => "alice"}
+          ],
+          "tags" => ["happy", "life", "blessed", "inspiration"],
+          "metadata" => %{
+            "created_at" => "2023-01-01T10:00:00Z",
+            "updated_at" => "2023-01-01T10:15:00Z",
+            "location" => "New York",
+            "device" => "mobile",
+            "engagement_score" => 8.5
+          },
+          "reactions" => %{
+            "likes" => 45,
+            "shares" => 12,
+            "hearts" => 23
+          }
+        }
+      },
+      "Deep Nesting - Configuration Tree" => %{
+        doc: %{
+          "application" => %{
+            "name" => "MyApp",
+            "version" => "1.0.0",
+            "modules" => %{
+              "authentication" => %{
+                "enabled" => true,
+                "providers" => %{
+                  "oauth" => %{
+                    "google" => %{"client_id" => "123", "scopes" => ["email", "profile"]},
+                    "github" => %{"client_id" => "456", "scopes" => ["user:email"]}
+                  },
+                  "local" => %{"enabled" => true, "password_policy" => %{"min_length" => 8}}
+                }
+              },
+              "database" => %{
+                "primary" => %{
+                  "host" => "localhost",
+                  "port" => 5432,
+                  "name" => "myapp_db",
+                  "pool" => %{"size" => 10, "timeout" => 5000}
+                },
+                "replica" => %{
+                  "host" => "replica.example.com",
+                  "port" => 5432,
+                  "name" => "myapp_db"
+                }
+              }
+            }
+          }
+        },
+        expected: %{
+          "application" => %{
+            "name" => "MyApp",
+            "version" => "1.1.0",
+            "modules" => %{
+              "authentication" => %{
+                "enabled" => true,
+                "providers" => %{
+                  "oauth" => %{
+                    "google" => %{
+                      "client_id" => "123",
+                      "scopes" => ["email", "profile", "calendar"]
+                    },
+                    "github" => %{"client_id" => "789", "scopes" => ["user:email", "read:user"]},
+                    "microsoft" => %{"client_id" => "999", "scopes" => ["User.Read"]}
+                  },
+                  "local" => %{
+                    "enabled" => true,
+                    "password_policy" => %{"min_length" => 12, "require_symbols" => true}
+                  },
+                  "saml" => %{
+                    "enabled" => false,
+                    "metadata_url" => "https://sso.example.com/metadata"
+                  }
+                }
+              },
+              "database" => %{
+                "primary" => %{
+                  "host" => "db.example.com",
+                  "port" => 5432,
+                  "name" => "myapp_production",
+                  "pool" => %{"size" => 20, "timeout" => 10_000, "idle_timeout" => 30_000}
+                },
+                "cache" => %{
+                  "host" => "redis.example.com",
+                  "port" => 6379,
+                  "ttl" => 3600
+                }
+              },
+              "monitoring" => %{
+                "metrics" => %{"enabled" => true, "interval" => 60},
+                "logging" => %{"level" => "info", "format" => "json"}
+              }
+            },
+            "features" => %{
+              "feature_flags" => %{"new_ui" => true, "beta_features" => false}
+            }
+          }
+        }
+      }
+    }
+  end
+
+  @doc """
+  Run the benchmark
+  """
+  def run_benchmark() do
+    Benchee.run(
+      %{
+        # I was using it for performance comparision, now faster version is the default one
+        # "Faster JsonPatch" => fn %{doc: doc, expected: expected} ->
+        #   Jsonpatch.Faster.diff(doc, expected)
+        # end,
+        "JsonPatch" => fn %{doc: doc, expected: expected} ->
+          Jsonpatch.diff(doc, expected)
+        end
+      },
+      inputs: prepare_test_cases(),
+      warmup: 0.1,
+      time: 0.5,
+      memory_time: 0.2,
+      reduction_time: 0.2,
+      parallel: 2,
+      formatters: [
+        Benchee.Formatters.Console
+      ],
+      print: [
+        benchmarking: true,
+        configuration: false,
+        fast_warning: false
+      ]
+    )
+  end
+end
+
+# Run the benchmark
+JsonpatchBenchmark.run_benchmark()

--- a/benchmarks/object_hash_benchmark.exs
+++ b/benchmarks/object_hash_benchmark.exs
@@ -1,0 +1,420 @@
+# Object Hash List Diff Performance Benchmark
+# Run with: mix run object_hash_benchmark.exs
+
+defmodule ObjectHashBenchmark do
+  @doc """
+  Prepare test cases focused on list diffing with object hashing
+  """
+  def prepare_test_cases() do
+    %{
+      "Small List (20 items)" => prepare_list_case(20),
+      "Medium List (100 items)" => prepare_list_case(100),
+      "Large List (500 items)" => prepare_list_case(500),
+      "Very Large List (1000 items)" => prepare_list_case(1_000),
+      "Nested Lists - User Management" => prepare_nested_case(),
+      "Complex Objects - Product Catalog" => prepare_complex_objects_case(),
+      "Mixed Operations - Social Feed" => prepare_mixed_operations_case()
+    }
+  end
+
+  defp prepare_list_case(size) do
+    # Create original list with sequential IDs
+    original =
+      1..size
+      |> Enum.map(fn id ->
+        %{
+          "id" => id,
+          "name" => "Item #{id}",
+          "status" => Enum.random(["active", "inactive", "pending"]),
+          "value" => :rand.uniform(1_000),
+          "metadata" => %{
+            "created_at" => "2023-01-#{rem(id, 28) + 1}T10:00:00Z",
+            "category" => Enum.random(["A", "B", "C", "D"])
+          }
+        }
+      end)
+
+    # Create modified list with various operations:
+    # - Remove some items (every 7th item)
+    # - Modify some items (every 5th item)
+    # - Add new items
+    # - Reorder some items
+    modified =
+      original
+      |> Enum.reject(fn %{"id" => id} -> rem(id, 7) == 0 end)  # Remove every 7th
+      |> Enum.map(fn item ->
+        if rem(item["id"], 5) == 0 do
+          # Modify every 5th item
+          %{item | "name" => "Modified #{item["name"]}", "value" => item["value"] * 2}
+        else
+          item
+        end
+      end)
+      |> then(fn list ->
+        # Add some new items
+        new_items =
+          (size + 1)..(size + div(size, 10))
+          |> Enum.map(fn id ->
+            %{
+              "id" => id,
+              "name" => "New Item #{id}",
+              "status" => "new",
+              "value" => :rand.uniform(1_000),
+              "metadata" => %{
+                "created_at" => "2023-12-01T10:00:00Z",
+                "category" => "NEW"
+              }
+            }
+          end)
+
+        list ++ new_items
+      end)
+      |> Enum.shuffle()  # Reorder items
+
+    %{doc: original, expected: modified}
+  end
+
+  defp prepare_nested_case() do
+    original = %{
+      "users" => [
+        %{
+          "id" => 1,
+          "name" => "Alice",
+          "permissions" => [
+            %{"id" => 101, "resource" => "posts", "action" => "read"},
+            %{"id" => 102, "resource" => "posts", "action" => "write"},
+            %{"id" => 103, "resource" => "users", "action" => "read"}
+          ]
+        },
+        %{
+          "id" => 2,
+          "name" => "Bob",
+          "permissions" => [
+            %{"id" => 201, "resource" => "posts", "action" => "read"},
+            %{"id" => 202, "resource" => "comments", "action" => "write"}
+          ]
+        },
+        %{
+          "id" => 3,
+          "name" => "Charlie",
+          "permissions" => [
+            %{"id" => 301, "resource" => "posts", "action" => "read"}
+          ]
+        }
+      ],
+      "groups" => [
+        %{
+          "id" => 10,
+          "name" => "Admins",
+          "members" => [
+            %{"id" => 1, "role" => "owner"},
+            %{"id" => 2, "role" => "admin"}
+          ]
+        },
+        %{
+          "id" => 20,
+          "name" => "Users",
+          "members" => [
+            %{"id" => 2, "role" => "member"},
+            %{"id" => 3, "role" => "member"}
+          ]
+        }
+      ]
+    }
+
+    expected = %{
+      "users" => [
+        %{
+          "id" => 1,
+          "name" => "Alice Smith",
+          "permissions" => [
+            %{"id" => 101, "resource" => "posts", "action" => "read"},
+            %{"id" => 102, "resource" => "posts", "action" => "write"},
+            %{"id" => 103, "resource" => "users", "action" => "read"},
+            %{"id" => 104, "resource" => "users", "action" => "write"}
+          ]
+        },
+        %{
+          "id" => 4,
+          "name" => "David",
+          "permissions" => [
+            %{"id" => 401, "resource" => "posts", "action" => "read"}
+          ]
+        },
+        %{
+          "id" => 3,
+          "name" => "Charlie Brown",
+          "permissions" => [
+            %{"id" => 301, "resource" => "posts", "action" => "read"},
+            %{"id" => 302, "resource" => "comments", "action" => "read"}
+          ]
+        }
+      ],
+      "groups" => [
+        %{
+          "id" => 10,
+          "name" => "Administrators",
+          "members" => [
+            %{"id" => 1, "role" => "owner"},
+            %{"id" => 4, "role" => "admin"}
+          ]
+        },
+        %{
+          "id" => 30,
+          "name" => "Moderators",
+          "members" => [
+            %{"id" => 3, "role" => "moderator"}
+          ]
+        }
+      ]
+    }
+
+    %{doc: original, expected: expected}
+  end
+
+  defp prepare_complex_objects_case() do
+    original = [
+      %{
+        "id" => "prod-001",
+        "name" => "Laptop Pro",
+        "price" => 1299.99,
+        "variants" => [
+          %{"id" => "var-001", "color" => "silver", "storage" => "256GB", "stock" => 10},
+          %{"id" => "var-002", "color" => "space-gray", "storage" => "512GB", "stock" => 5}
+        ],
+        "reviews" => [
+          %{"id" => "rev-001", "rating" => 5, "comment" => "Excellent!"},
+          %{"id" => "rev-002", "rating" => 4, "comment" => "Very good"}
+        ]
+      },
+      %{
+        "id" => "prod-002",
+        "name" => "Wireless Mouse",
+        "price" => 79.99,
+        "variants" => [
+          %{"id" => "var-003", "color" => "black", "connectivity" => "bluetooth", "stock" => 25},
+          %{"id" => "var-004", "color" => "white", "connectivity" => "usb", "stock" => 15}
+        ],
+        "reviews" => [
+          %{"id" => "rev-003", "rating" => 4, "comment" => "Good quality"}
+        ]
+      },
+      %{
+        "id" => "prod-003",
+        "name" => "Keyboard",
+        "price" => 129.99,
+        "variants" => [
+          %{"id" => "var-005", "layout" => "US", "switches" => "mechanical", "stock" => 8}
+        ],
+        "reviews" => []
+      }
+    ]
+
+    expected = [
+      %{
+        "id" => "prod-001",
+        "name" => "Laptop Pro Max",
+        "price" => 1499.99,
+        "variants" => [
+          %{"id" => "var-001", "color" => "silver", "storage" => "256GB", "stock" => 8},
+          %{"id" => "var-002", "color" => "space-gray", "storage" => "512GB", "stock" => 3},
+          %{"id" => "var-006", "color" => "gold", "storage" => "1TB", "stock" => 2}
+        ],
+        "reviews" => [
+          %{"id" => "rev-001", "rating" => 5, "comment" => "Excellent product!"},
+          %{"id" => "rev-002", "rating" => 4, "comment" => "Very good"},
+          %{"id" => "rev-004", "rating" => 5, "comment" => "Amazing performance"}
+        ]
+      },
+      %{
+        "id" => "prod-004",
+        "name" => "Wireless Headphones",
+        "price" => 199.99,
+        "variants" => [
+          %{"id" => "var-007", "color" => "black", "noise_cancelling" => true, "stock" => 12}
+        ],
+        "reviews" => [
+          %{"id" => "rev-005", "rating" => 5, "comment" => "Great sound quality"}
+        ]
+      },
+      %{
+        "id" => "prod-003",
+        "name" => "Mechanical Keyboard",
+        "price" => 149.99,
+        "variants" => [
+          %{"id" => "var-005", "layout" => "US", "switches" => "mechanical", "stock" => 12},
+          %{"id" => "var-008", "layout" => "UK", "switches" => "mechanical", "stock" => 5}
+        ],
+        "reviews" => [
+          %{"id" => "rev-006", "rating" => 4, "comment" => "Solid build quality"}
+        ]
+      }
+    ]
+
+    %{doc: original, expected: expected}
+  end
+
+  defp prepare_mixed_operations_case() do
+    # Simulate a social media feed with posts, comments, and reactions
+    original = [
+      %{
+        "id" => "post-1",
+        "content" => "Beautiful sunset today!",
+        "author" => "alice",
+        "timestamp" => "2023-01-01T18:00:00Z",
+        "comments" => [
+          %{"id" => "comment-1", "author" => "bob", "text" => "Amazing!"},
+          %{"id" => "comment-2", "author" => "charlie", "text" => "Where was this?"}
+        ],
+        "reactions" => [
+          %{"id" => "react-1", "user" => "bob", "type" => "like"},
+          %{"id" => "react-2", "user" => "charlie", "type" => "love"}
+        ]
+      },
+      %{
+        "id" => "post-2",
+        "content" => "Just finished my morning run!",
+        "author" => "bob",
+        "timestamp" => "2023-01-02T08:00:00Z",
+        "comments" => [
+          %{"id" => "comment-3", "author" => "alice", "text" => "Great job!"}
+        ],
+        "reactions" => [
+          %{"id" => "react-3", "user" => "alice", "type" => "like"}
+        ]
+      },
+      %{
+        "id" => "post-3",
+        "content" => "Working on a new project",
+        "author" => "charlie",
+        "timestamp" => "2023-01-03T14:00:00Z",
+        "comments" => [],
+        "reactions" => []
+      }
+    ]
+
+    expected = [
+      %{
+        "id" => "post-1",
+        "content" => "Beautiful sunset today! #nature",
+        "author" => "alice",
+        "timestamp" => "2023-01-01T18:00:00Z",
+        "comments" => [
+          %{"id" => "comment-1", "author" => "bob", "text" => "Amazing! Where is this?"},
+          %{"id" => "comment-4", "author" => "david", "text" => "Stunning colors!"}
+        ],
+        "reactions" => [
+          %{"id" => "react-1", "user" => "bob", "type" => "like"},
+          %{"id" => "react-2", "user" => "charlie", "type" => "love"},
+          %{"id" => "react-4", "user" => "david", "type" => "wow"}
+        ]
+      },
+      %{
+        "id" => "post-4",
+        "content" => "New coffee shop discovery!",
+        "author" => "david",
+        "timestamp" => "2023-01-04T09:00:00Z",
+        "comments" => [
+          %{"id" => "comment-5", "author" => "alice", "text" => "I need to try this!"}
+        ],
+        "reactions" => [
+          %{"id" => "react-5", "user" => "alice", "type" => "like"}
+        ]
+      },
+      %{
+        "id" => "post-3",
+        "content" => "Working on a new exciting project!",
+        "author" => "charlie",
+        "timestamp" => "2023-01-03T14:00:00Z",
+        "comments" => [
+          %{"id" => "comment-6", "author" => "bob", "text" => "Can't wait to see it!"}
+        ],
+        "reactions" => [
+          %{"id" => "react-6", "user" => "bob", "type" => "like"}
+        ]
+      }
+    ]
+
+    %{doc: original, expected: expected}
+  end
+
+  @doc """
+  Hash function for objects with ID
+  """
+  def id_hash_fn(%{"id" => id}), do: id
+  # def id_hash_fn(string) when is_binary(string), do: string
+  def id_hash_fn(_item), do: raise "Unable to find hash"
+
+  @doc """
+  Run the benchmark comparing with and without object_hash
+  """
+  def run_benchmark() do
+    Benchee.run(
+      %{
+        "Without object_hash (pairwise)" => fn %{doc: doc, expected: expected} ->
+          Jsonpatch.diff(doc, expected)
+        end,
+        "With object_hash (greedy)" => fn %{doc: doc, expected: expected} ->
+          Jsonpatch.diff(doc, expected, object_hash: &id_hash_fn/1)
+        end,
+      },
+      inputs: prepare_test_cases(),
+      warmup: 0.2,
+      time: 1.0,
+      memory_time: 0.5,
+      reduction_time: 0.5,
+      parallel: 1,
+      formatters: [
+        Benchee.Formatters.Console
+      ],
+      print: [
+        benchmarking: true,
+        configuration: true,
+        fast_warning: false
+      ]
+    )
+  end
+
+  @doc """
+  Run a detailed analysis showing the patches generated
+  """
+  def analyze_patches() do
+    IO.puts("=== Patch Analysis ===\n")
+
+    test_cases = prepare_test_cases()
+
+    Enum.each(test_cases, fn {name, %{doc: doc, expected: expected}} ->
+      IO.puts("## #{name}")
+
+      patches_without_hash = Jsonpatch.diff(doc, expected)
+      patches_with_hash = Jsonpatch.diff(doc, expected, object_hash: &id_hash_fn/1)
+
+      IO.puts("Without object_hash: #{length(patches_without_hash)} patches")
+      IO.puts("With object_hash: #{length(patches_with_hash)} patches")
+
+      # # Show first few patches for comparison
+      # IO.puts("\nFirst 3 patches without object_hash:")
+      # patches_without_hash |> Enum.take(3) |> Enum.each(&IO.inspect/1)
+
+      IO.puts("")
+
+      # IO.puts("\nFirst 3 patches with object_hash:")
+      # patches_with_hash |> Enum.take(3) |> Enum.each(&IO.inspect/1)
+
+      IO.puts("Result with object_hash: #{Jsonpatch.apply_patch!(patches_with_hash, doc) == expected}")
+      IO.puts("Result without object_hash: #{Jsonpatch.apply_patch!(patches_without_hash, doc) == expected}")
+      IO.puts("\n" <> String.duplicate("-", 50) <> "\n")
+
+    end)
+  end
+end
+
+# Run the benchmark
+IO.puts("Starting Object Hash Benchmark...")
+IO.puts("This benchmark compares list diffing performance with and without object_hash option.")
+IO.puts("The object_hash option uses LCS algorithm to better handle list reordering.\n")
+
+ObjectHashBenchmark.run_benchmark()
+
+# Uncomment to see patch analysis
+# ObjectHashBenchmark.analyze_patches()

--- a/lib/jsonpatch/types.ex
+++ b/lib/jsonpatch/types.ex
@@ -27,12 +27,24 @@ defmodule Jsonpatch.Types do
           :strings | :atoms | {:custom, convert_fn()} | {:ignore_invalid_paths, :boolean}
 
   @typedoc """
-  Types options:
+  Apply patch options:
 
-  - `:keys` - controls how path fragments are decoded.
+  - `:keys` - controls how path fragments are decoded
   """
   @type opts :: [{:keys, opt_keys()}]
-  @type opts_diff :: [{:ancestor_path, String.t()} | {:prepare_map, (struct() | map() -> map())}]
+
+  @typedoc """
+  Diff options:
+
+  - `:ancestor_path` - path to the ancestor of the current node
+  - `:prepare_map` - function to prepare the map for diffing
+  - `:object_hash` - function to extract unique identifier from list items for optimized diffing.
+  """
+  @type opts_diff :: [
+          {:ancestor_path, String.t()}
+          | {:prepare_map, (struct() | map() -> map())}
+          | {:object_hash, (term() -> term())}
+        ]
 
   @type casted_array_index :: :- | non_neg_integer()
   @type casted_object_key :: atom() | String.t()

--- a/test/jsonpatch_test.exs
+++ b/test/jsonpatch_test.exs
@@ -420,7 +420,6 @@ defmodule JsonpatchTest do
              ]
     end
 
-    @tag :wip
     test "Create diff with object_hash for list items - modification" do
       original = [
         %{id: 1, name: "test1"},


### PR DESCRIPTION
I've spent way too much time on this, but I have a fast, working implementation of greedy algorithm detecting patches using object_hash opts, as asked in #26 

My benchmarks show it's between 2-5 times faster, thanks to reducing number of deep comparisions. If hash can't be computed, we fall back to pairwise comparision.

Created patches are optimal when there are only additions / removals, no matter where in list. I don't detect moves - tried to do it, but it's a can of worms. For now moves are mapped to pair of remove + add. 

Implemented also an LCS-based solution, but it was slow and detecting conflicting moves was very complex. Decided to rewrite with a simpler solution.

Feel free to check tests. That branch is based on diff-performance-optimizations, should be more readable after merging performance fixes. 

TODO:
- [ ] Documentation

benchmark:
```bash
Benchmarking With object_hash (greedy) with input Complex Objects - Product Catalog ...
Benchmarking With object_hash (greedy) with input Large List (500 items) ...
Benchmarking With object_hash (greedy) with input Medium List (100 items) ...
Benchmarking With object_hash (greedy) with input Mixed Operations - Social Feed ...
Benchmarking With object_hash (greedy) with input Nested Lists - User Management ...
Benchmarking With object_hash (greedy) with input Small List (20 items) ...
Benchmarking With object_hash (greedy) with input Very Large List (1000 items) ...
Benchmarking Without object_hash (pairwise) with input Complex Objects - Product Catalog ...
Benchmarking Without object_hash (pairwise) with input Large List (500 items) ...
Benchmarking Without object_hash (pairwise) with input Medium List (100 items) ...
Benchmarking Without object_hash (pairwise) with input Mixed Operations - Social Feed ...
Benchmarking Without object_hash (pairwise) with input Nested Lists - User Management ...
Benchmarking Without object_hash (pairwise) with input Small List (20 items) ...
Benchmarking Without object_hash (pairwise) with input Very Large List (1000 items) ...
Calculating statistics...
Formatting results...

##### With input Complex Objects - Product Catalog #####
Name                                     ips        average  deviation         median         99th %
With object_hash (greedy)            88.31 K       11.32 μs   ±214.54%        9.67 μs       35.43 μs
Without object_hash (pairwise)       74.66 K       13.39 μs    ±87.12%       12.04 μs       31.21 μs

Comparison: 
With object_hash (greedy)            88.31 K
Without object_hash (pairwise)       74.66 K - 1.18x slower +2.07 μs

Memory usage statistics:

Name                              Memory usage
With object_hash (greedy)             10.20 KB
Without object_hash (pairwise)         9.72 KB - 0.95x memory usage -0.48438 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                           Reduction count
With object_hash (greedy)               1.22 K
Without object_hash (pairwise)          1.04 K - 0.85x reduction count -0.18300 K

**All measurements for reduction count were the same**

##### With input Large List (500 items) #####
Name                                     ips        average  deviation         median         99th %
With object_hash (greedy)             3.42 K        0.29 ms    ±22.15%        0.27 ms        0.48 ms
Without object_hash (pairwise)        0.62 K        1.62 ms    ±12.16%        1.59 ms        2.26 ms

Comparison: 
With object_hash (greedy)             3.42 K
Without object_hash (pairwise)        0.62 K - 5.54x slower +1.33 ms

Memory usage statistics:

Name                              Memory usage
With object_hash (greedy)            445.83 KB
Without object_hash (pairwise)       906.92 KB - 2.03x memory usage +461.09 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                           Reduction count
With object_hash (greedy)              25.14 K
Without object_hash (pairwise)         89.90 K - 3.58x reduction count +64.77 K

**All measurements for reduction count were the same**

##### With input Medium List (100 items) #####
Name                                     ips        average  deviation         median         99th %
With object_hash (greedy)            19.45 K       51.42 μs    ±18.82%       49.63 μs       75.85 μs
Without object_hash (pairwise)        3.03 K      330.16 μs    ±35.01%      320.92 μs      519.85 μs

Comparison: 
With object_hash (greedy)            19.45 K
Without object_hash (pairwise)        3.03 K - 6.42x slower +278.75 μs

Memory usage statistics:

Name                              Memory usage
With object_hash (greedy)             87.38 KB
Without object_hash (pairwise)       177.93 KB - 2.04x memory usage +90.55 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                           Reduction count
With object_hash (greedy)               5.41 K
Without object_hash (pairwise)         16.30 K - 3.01x reduction count +10.89 K

**All measurements for reduction count were the same**

##### With input Mixed Operations - Social Feed #####
Name                                     ips        average  deviation         median         99th %
With object_hash (greedy)           126.17 K        7.93 μs    ±79.47%        7.29 μs       20.21 μs
Without object_hash (pairwise)       90.90 K       11.00 μs    ±40.83%       10.08 μs       27.04 μs

Comparison: 
With object_hash (greedy)           126.17 K
Without object_hash (pairwise)       90.90 K - 1.39x slower +3.08 μs

Memory usage statistics:

Name                              Memory usage
With object_hash (greedy)              7.95 KB
Without object_hash (pairwise)         7.47 KB - 0.94x memory usage -0.48438 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                           Reduction count
With object_hash (greedy)                  941
Without object_hash (pairwise)             826 - 0.88x reduction count -115

**All measurements for reduction count were the same**

##### With input Nested Lists - User Management #####
Name                                     ips        average  deviation         median         99th %
With object_hash (greedy)           109.85 K        9.10 μs   ±345.27%        7.42 μs       24.91 μs
Without object_hash (pairwise)       98.71 K       10.13 μs    ±32.27%        9.38 μs       27.42 μs

Comparison: 
With object_hash (greedy)           109.85 K
Without object_hash (pairwise)       98.71 K - 1.11x slower +1.03 μs

Memory usage statistics:

Name                              Memory usage
With object_hash (greedy)              8.40 KB
Without object_hash (pairwise)         6.83 KB - 0.81x memory usage -1.57031 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                           Reduction count
With object_hash (greedy)                  998
Without object_hash (pairwise)             776 - 0.78x reduction count -222

**All measurements for reduction count were the same**

##### With input Small List (20 items) #####
Name                                     ips        average  deviation         median         99th %
With object_hash (greedy)           112.15 K        8.92 μs   ±222.21%        7.17 μs       43.81 μs
Without object_hash (pairwise)       19.54 K       51.18 μs    ±28.79%          49 μs       93.25 μs

Comparison: 
With object_hash (greedy)           112.15 K
Without object_hash (pairwise)       19.54 K - 5.74x slower +42.27 μs

Memory usage statistics:

Name                              Memory usage
With object_hash (greedy)             16.63 KB
Without object_hash (pairwise)        35.44 KB - 2.13x memory usage +18.80 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                           Reduction count
With object_hash (greedy)               1.19 K
Without object_hash (pairwise)          3.36 K - 2.83x reduction count +2.17 K

**All measurements for reduction count were the same**

##### With input Very Large List (1000 items) #####
Name                                     ips        average  deviation         median         99th %
With object_hash (greedy)             1.77 K        0.56 ms    ±18.26%        0.54 ms        1.07 ms
Without object_hash (pairwise)        0.32 K        3.13 ms    ±15.77%        3.06 ms        5.09 ms

Comparison: 
With object_hash (greedy)             1.77 K
Without object_hash (pairwise)        0.32 K - 5.55x slower +2.56 ms

Memory usage statistics:

Name                              Memory usage
With object_hash (greedy)              0.93 MB
Without object_hash (pairwise)         1.76 MB - 1.90x memory usage +0.83 MB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                           Reduction count
With object_hash (greedy)              52.62 K
Without object_hash (pairwise)        165.64 K - 3.15x reduction count +113.01 K

**All measurements for reduction count were the same**
```