### PR TITLE
Add ancestor_path option to diff function for nested structures

### DIFF
--- a/lib/jsonpatch.ex
+++ b/lib/jsonpatch.ex
@@ -190,7 +190,7 @@ defmodule Jsonpatch do
         %{path: "/nested/a", value: 3, op: "replace"}
       ]
   """
-  @spec diff(Types.json_container(), Types.json_container(), Types.opts()) :: [Jsonpatch.t()]
+  @spec diff(Types.json_container(), Types.json_container(), Types.opts_diff()) :: [Jsonpatch.t()]
   def diff(source, destination, opts \\ []) do
     opts = Keyword.validate!(opts, ancestor_path: "")
 

--- a/lib/jsonpatch/types.ex
+++ b/lib/jsonpatch/types.ex
@@ -32,6 +32,7 @@ defmodule Jsonpatch.Types do
   - `:keys` - controls how path fragments are decoded.
   """
   @type opts :: [{:keys, opt_keys()}]
+  @type opts_diff :: [{:ancestor_path, String.t()}]
 
   @type casted_array_index :: :- | non_neg_integer()
   @type casted_object_key :: atom() | String.t()


### PR DESCRIPTION
Enhanced the diff function to accept an `:ancestor_path` option, allowing users to specify a starting point for diffing nested maps and lists. 

Added tests to verify functionality with various ancestor paths, including handling of escaped characters.

Fixes #30 