### PR TITLE
Prepare struct option

### DIFF
--- a/lib/jsonpatch.ex
+++ b/lib/jsonpatch.ex
@@ -190,7 +190,7 @@ defmodule Jsonpatch do
         %{path: "/nested/a", value: 3, op: "replace"}
       ]
   """
-  @spec diff(Types.json_container(), Types.json_container(), Types.opts()) :: [Jsonpatch.t()]
+  @spec diff(Types.json_container(), Types.json_container(), Types.opts_diff()) :: [Jsonpatch.t()]
   def diff(source, destination, opts \\ []) do
     opts = Keyword.validate!(opts, ancestor_path: "")
 

--- a/lib/jsonpatch.ex
+++ b/lib/jsonpatch.ex
@@ -192,14 +192,18 @@ defmodule Jsonpatch do
   """
   @spec diff(Types.json_container(), Types.json_container(), Types.opts_diff()) :: [Jsonpatch.t()]
   def diff(source, destination, opts \\ []) do
-    opts = Keyword.validate!(opts, ancestor_path: "")
+    opts =
+      Keyword.validate!(opts,
+        ancestor_path: "",
+        prepare_struct: fn struct -> Map.from_struct(struct) end
+      )
 
     cond do
       is_map(source) and is_map(destination) ->
-        do_map_diff(destination, source, opts[:ancestor_path])
+        do_map_diff(destination, source, opts[:ancestor_path], [], opts)
 
       is_list(source) and is_list(destination) ->
-        do_list_diff(destination, source, opts[:ancestor_path])
+        do_list_diff(destination, source, opts[:ancestor_path], [], 0, opts)
 
       true ->
         []
@@ -209,34 +213,38 @@ defmodule Jsonpatch do
   defguardp are_unequal_maps(val1, val2) when val1 != val2 and is_map(val2) and is_map(val1)
   defguardp are_unequal_lists(val1, val2) when val1 != val2 and is_list(val2) and is_list(val1)
 
-  defp do_diff(dest, source, path, key, patches) when are_unequal_lists(dest, source) do
+  defp do_diff(dest, source, path, key, patches, opts) when are_unequal_lists(dest, source) do
     # uneqal lists, let's use a specialized function for that
-    do_list_diff(dest, source, "#{path}/#{escape(key)}", patches)
+    do_list_diff(dest, source, "#{path}/#{escape(key)}", patches, 0, opts)
   end
 
-  defp do_diff(dest, source, path, key, patches) when are_unequal_maps(dest, source) do
+  defp do_diff(dest, source, path, key, patches, opts) when are_unequal_maps(dest, source) do
     # uneqal maps, let's use a specialized function for that
-    do_map_diff(dest, source, "#{path}/#{escape(key)}", patches)
+    do_map_diff(dest, source, "#{path}/#{escape(key)}", patches, opts)
   end
 
-  defp do_diff(dest, source, path, key, patches) when dest != source do
+  defp do_diff(dest, source, path, key, patches, _opts) when dest != source do
     # scalar values or change of type (map -> list etc), let's just make a replace patch
     [%{op: "replace", path: "#{path}/#{escape(key)}", value: dest} | patches]
   end
 
-  defp do_diff(_dest, _source, _path, _key, patches) do
+  defp do_diff(_dest, _source, _path, _key, patches, _opts) do
     # no changes, return patches as is
     patches
   end
 
-  defp do_map_diff(%{} = destination, %{} = source, ancestor_path, patches \\ []) do
+  defp do_map_diff(%{} = destination, %{} = source, ancestor_path, patches, opts) do
+    # Convert structs to maps if prepare_struct function is provided
+    destination = maybe_prepare_struct(destination, opts)
+    source = maybe_prepare_struct(source, opts)
+
     # entrypoint for map diff, let's convert the map to a list of {k, v} tuples
     destination
     |> Map.to_list()
-    |> do_map_diff(source, ancestor_path, patches, [])
+    |> do_map_diff(source, ancestor_path, patches, [], opts)
   end
 
-  defp do_map_diff([], source, ancestor_path, patches, checked_keys) do
+  defp do_map_diff([], source, ancestor_path, patches, checked_keys, _opts) do
     # The complete desination was check. Every key that is not in the list of
     # checked keys, must be removed.
     Enum.reduce(source, patches, fn {k, _}, patches ->
@@ -248,29 +256,29 @@ defmodule Jsonpatch do
     end)
   end
 
-  defp do_map_diff([{key, val} | rest], source, ancestor_path, patches, checked_keys) do
+  defp do_map_diff([{key, val} | rest], source, ancestor_path, patches, checked_keys, opts) do
     # normal iteration through list of map {k, v} tuples. We track seen keys to later remove not seen keys.
     patches =
       case Map.fetch(source, key) do
-        {:ok, source_val} -> do_diff(val, source_val, ancestor_path, key, patches)
+        {:ok, source_val} -> do_diff(val, source_val, ancestor_path, key, patches, opts)
         :error -> [%{op: "add", path: "#{ancestor_path}/#{escape(key)}", value: val} | patches]
       end
 
     # Diff next value of same level
-    do_map_diff(rest, source, ancestor_path, patches, [key | checked_keys])
+    do_map_diff(rest, source, ancestor_path, patches, [key | checked_keys], opts)
   end
 
-  defp do_list_diff(destination, source, ancestor_path, patches \\ [], idx \\ 0)
+  defp do_list_diff(destination, source, ancestor_path, patches, idx, opts)
 
-  defp do_list_diff([], [], _path, patches, _idx), do: patches
+  defp do_list_diff([], [], _path, patches, _idx, _opts), do: patches
 
-  defp do_list_diff([], [_item | source_rest], ancestor_path, patches, idx) do
+  defp do_list_diff([], [_item | source_rest], ancestor_path, patches, idx, opts) do
     # if we find any leftover items in source, we have to remove them
     patches = [%{op: "remove", path: "#{ancestor_path}/#{idx}"} | patches]
-    do_list_diff([], source_rest, ancestor_path, patches, idx + 1)
+    do_list_diff([], source_rest, ancestor_path, patches, idx + 1, opts)
   end
 
-  defp do_list_diff(items, [], ancestor_path, patches, idx) do
+  defp do_list_diff(items, [], ancestor_path, patches, idx, _opts) do
     # we have to do it without recursion, because we have to keep the order of the items
     items
     |> Enum.map_reduce(idx, fn val, idx ->
@@ -280,11 +288,18 @@ defmodule Jsonpatch do
     |> Kernel.++(patches)
   end
 
-  defp do_list_diff([val | rest], [source_val | source_rest], ancestor_path, patches, idx) do
+  defp do_list_diff([val | rest], [source_val | source_rest], ancestor_path, patches, idx, opts) do
     # case when there's an item in both desitation and source. Let's just compare them
-    patches = do_diff(val, source_val, ancestor_path, idx, patches)
-    do_list_diff(rest, source_rest, ancestor_path, patches, idx + 1)
+    patches = do_diff(val, source_val, ancestor_path, idx, patches, opts)
+    do_list_diff(rest, source_rest, ancestor_path, patches, idx + 1, opts)
   end
+
+  defp maybe_prepare_struct(value, opts) when is_struct(value) do
+    prepare_fn = Keyword.fetch!(opts, :prepare_struct)
+    prepare_fn.(value)
+  end
+
+  defp maybe_prepare_struct(value, _opts), do: value
 
   @compile {:inline, escape: 1}
 

--- a/lib/jsonpatch.ex
+++ b/lib/jsonpatch.ex
@@ -217,6 +217,11 @@ defmodule Jsonpatch do
       is_list(source) and is_list(destination) ->
         do_list_diff(destination, source, opts[:ancestor_path], [], 0, opts)
 
+      # type of value changed, eg set to nil
+      source != destination ->
+        destination = maybe_prepare_map(destination, opts)
+        [%{op: "replace", path: opts[:ancestor_path], value: destination}]
+
       true ->
         []
     end

--- a/lib/jsonpatch.ex
+++ b/lib/jsonpatch.ex
@@ -167,6 +167,17 @@ defmodule Jsonpatch do
 
     * `:ancestor_path` - Sets the initial ancestor path for the diff operation.
       Defaults to `""` (root). Useful when you need to diff starting from a nested path.
+    * `:prepare_struct` - A function that converts structs to maps before diffing.
+      Defaults to `fn struct -> struct end` (no-op). Useful when you need to customize
+      how structs are handled during the diff process. Example:
+
+      ```elixir
+      fn
+        %Struct{field1: value1, field2: value2} -> %{field1: "\#{value1} - \#{value2}"}
+        %OtherStruct{} = struct -> Map.take(struct, [:field1])
+        struct -> struct
+      end
+      ```
 
   ## Examples
 
@@ -195,7 +206,8 @@ defmodule Jsonpatch do
     opts =
       Keyword.validate!(opts,
         ancestor_path: "",
-        prepare_struct: fn struct -> Map.from_struct(struct) end
+        # by default, a no-op
+        prepare_struct: fn struct -> struct end
       )
 
     cond do

--- a/lib/jsonpatch/types.ex
+++ b/lib/jsonpatch/types.ex
@@ -32,7 +32,7 @@ defmodule Jsonpatch.Types do
   - `:keys` - controls how path fragments are decoded.
   """
   @type opts :: [{:keys, opt_keys()}]
-  @type opts_diff :: [{:ancestor_path, String.t()}]
+  @type opts_diff :: [{:ancestor_path, String.t()} | {:prepare_struct, (struct() -> map())}]
 
   @type casted_array_index :: :- | non_neg_integer()
   @type casted_object_key :: atom() | String.t()

--- a/lib/jsonpatch/types.ex
+++ b/lib/jsonpatch/types.ex
@@ -32,6 +32,7 @@ defmodule Jsonpatch.Types do
   - `:keys` - controls how path fragments are decoded.
   """
   @type opts :: [{:keys, opt_keys()}]
+  @type opts_diff :: [{:ancestor_path, String.t()}]
 
   @type casted_array_index :: :- | non_neg_integer()
   @type casted_object_key :: atom() | String.t()

--- a/lib/jsonpatch/types.ex
+++ b/lib/jsonpatch/types.ex
@@ -32,7 +32,7 @@ defmodule Jsonpatch.Types do
   - `:keys` - controls how path fragments are decoded.
   """
   @type opts :: [{:keys, opt_keys()}]
-  @type opts_diff :: [{:ancestor_path, String.t()} | {:prepare_struct, (struct() -> map())}]
+  @type opts_diff :: [{:ancestor_path, String.t()} | {:prepare_map, (struct() -> map())}]
 
   @type casted_array_index :: :- | non_neg_integer()
   @type casted_object_key :: atom() | String.t()

--- a/lib/jsonpatch/types.ex
+++ b/lib/jsonpatch/types.ex
@@ -32,7 +32,7 @@ defmodule Jsonpatch.Types do
   - `:keys` - controls how path fragments are decoded.
   """
   @type opts :: [{:keys, opt_keys()}]
-  @type opts_diff :: [{:ancestor_path, String.t()} | {:prepare_map, (struct() -> map())}]
+  @type opts_diff :: [{:ancestor_path, String.t()} | {:prepare_map, (struct() | map() -> map())}]
 
   @type casted_array_index :: :- | non_neg_integer()
   @type casted_object_key :: atom() | String.t()

--- a/test/jsonpatch_test.exs
+++ b/test/jsonpatch_test.exs
@@ -57,8 +57,8 @@ defmodule JsonpatchTest do
       assert [] = Jsonpatch.diff(source, destination)
     end
 
-    test "Create no diff on unexpected input" do
-      assert [] = Jsonpatch.diff("unexpected", 1)
+    test "Create full replace operation when type of root value changes" do
+      assert [%{op: "replace", path: "", value: 1}] = Jsonpatch.diff("unexpected", 1)
     end
 
     test "A.4. Removing an Array Element" do
@@ -322,6 +322,21 @@ defmodule JsonpatchTest do
       assert patches == [
                %{op: "replace", path: "/a", value: %{field1: "old"}}
              ]
+    end
+
+    test "Create diff with ancestor_path when changing type of base value (map to nil)" do
+      source = %{"key" => "value"}
+      destination = nil
+
+      patches = Jsonpatch.diff(source, destination, ancestor_path: "/nested")
+
+      # This should fail for now - the diff should not handle type changes with ancestor_path
+      # The expected behavior would be to generate a replace operation for the entire data object
+      expected_patches = [
+        %{op: "replace", path: "/nested", value: nil}
+      ]
+
+      assert patches == expected_patches
     end
 
     defp assert_diff_apply(source, destination) do

--- a/test/jsonpatch_test.exs
+++ b/test/jsonpatch_test.exs
@@ -262,6 +262,51 @@ defmodule JsonpatchTest do
       assert_equal_patches(patches, expected_patches)
     end
 
+    test "add map patches are correctly processed by prepare_struct" do
+      source = %{}
+
+      destination = %{
+        a: %TestStruct{
+          field1: "hi",
+          field2: "world"
+        }
+      }
+
+      patches = Jsonpatch.diff(source, destination, prepare_struct: &%{field1: &1.field1})
+
+      assert patches == [
+               %{op: "add", path: "/a", value: %{field1: "hi"}}
+             ]
+    end
+
+    test "add list patches are correctly processed by prepare_struct" do
+      source = []
+
+      destination = [
+        %TestStruct{
+          field1: "hi",
+          field2: "world"
+        }
+      ]
+
+      patches = Jsonpatch.diff(source, destination, prepare_struct: &%{field1: &1.field1})
+
+      assert patches == [
+               %{op: "add", path: "/0", value: %{field1: "hi"}}
+             ]
+    end
+
+    test "replace map patches are correctly processed by prepare_struct" do
+      source = %{"a" => "test"}
+      destination = %{"a" => %TestStruct{field1: "old"}}
+
+      patches = Jsonpatch.diff(source, destination, prepare_struct: &%{field1: &1.field1})
+
+      assert patches == [
+               %{op: "replace", path: "/a", value: %{field1: "old"}}
+             ]
+    end
+
     defp assert_diff_apply(source, destination) do
       patches = Jsonpatch.diff(source, destination)
       assert Jsonpatch.apply_patch(patches, source) == {:ok, destination}

--- a/test/jsonpatch_test.exs
+++ b/test/jsonpatch_test.exs
@@ -205,10 +205,12 @@ defmodule JsonpatchTest do
       patches =
         Jsonpatch.diff(source, destination, prepare_struct: &Map.take(&1, [:field1, :inner]))
 
-      assert patches == [
-               %{op: "replace", path: "/field1", value: "new_value"},
-               %{op: "replace", path: "/inner/nested", value: "new"}
-             ]
+      expected_patches = [
+        %{op: "replace", path: "/field1", value: "new_value"},
+        %{op: "replace", path: "/inner/nested", value: "new"}
+      ]
+
+      assert_equal_patches(patches, expected_patches)
     end
 
     test "Create diff with prepare_struct option using dynamic field creation" do
@@ -227,9 +229,11 @@ defmodule JsonpatchTest do
           prepare_struct: &%{field3: "#{&1.field1} - #{&1.field2}"}
         )
 
-      assert patches == [
-               %{op: "replace", path: "/field3", value: "hi - world"}
-             ]
+      expected_patches = [
+        %{op: "replace", path: "/field3", value: "hi - world"}
+      ]
+
+      assert_equal_patches(patches, expected_patches)
     end
 
     test "Create diff with prepare_struct option using nested dynamic field creation" do
@@ -250,10 +254,12 @@ defmodule JsonpatchTest do
           prepare_struct: &%{inner: &1.inner, field3: "#{&1.field1} - #{&1.field2}"}
         )
 
-      assert patches == [
-               %{op: "replace", path: "/field3", value: "hi - world"},
-               %{op: "replace", path: "/inner/field3", value: "nested - new"}
-             ]
+      expected_patches = [
+        %{op: "replace", path: "/field3", value: "hi - world"},
+        %{op: "replace", path: "/inner/field3", value: "nested - new"}
+      ]
+
+      assert_equal_patches(patches, expected_patches)
     end
 
     defp assert_diff_apply(source, destination) do
@@ -557,6 +563,10 @@ defmodule JsonpatchTest do
       assert {:ok, %{"foo" => "bar"}} =
                Jsonpatch.apply_patch(patch, target, ignore_invalid_paths: true)
     end
+  end
+
+  defp assert_equal_patches(patches1, patches2) do
+    assert Enum.sort_by(patches1, & &1.path) == Enum.sort_by(patches2, & &1.path)
   end
 
   defp string_to_existing_atom(data) when is_binary(data) do


### PR DESCRIPTION
I've added a new option to diff letting to customize structs before diffing them. By default it does nothing, but can be used to nicely customize diff behaviour for your structs.

I've built that PR on top of #33, so that other one should be merged first.


Fixes #29 